### PR TITLE
Delete --project command line option to make it configurable

### DIFF
--- a/vars/owaspDependencyCheck.groovy
+++ b/vars/owaspDependencyCheck.groovy
@@ -3,7 +3,7 @@ def call(Map args = [:], String... scanDirs) {
     withEnv(["PATH+DC=${tool name: args.tool, type: 'dependency-check'}/bin"]) {                    
         sh 'mkdir -p data report'
         scanArgs = scanDirs.collect { "--scan '$it'"}.join(' ')
-        sh "dependency-check.sh ${scanArgs} --format 'ALL' --project 'OWASP Dependency Check' --out report ${args.extraArgs}"
+        sh "dependency-check.sh ${scanArgs} --format 'ALL' --out report ${args.extraArgs}"
     }
     dependencyCheckPublisher pattern: 'report/dependency-check-report.xml'
 }

--- a/vars/owaspDependencyCheck.txt
+++ b/vars/owaspDependencyCheck.txt
@@ -69,7 +69,7 @@
             <dt><code>--project <files></code></dt>
             <dd>
                 <p>
-                    The name of the project being scanned.
+                    The name of the project being scanned. This project name is displayed as a heading in the report.
                 </p>
             </dd>
         </dl>

--- a/vars/owaspDependencyCheck.txt
+++ b/vars/owaspDependencyCheck.txt
@@ -66,6 +66,12 @@
                     information see: https://jeremylong.github.io/DependencyCheck/general/suppression.html.
                 </p>
             </dd>
+            <dt><code>--project <files></code></dt>
+            <dd>
+                <p>
+                    The name of the project being scanned.
+                </p>
+            </dd>
         </dl>
     </dd>
 


### PR DESCRIPTION
The project command line option is currently not configurable because it's set in the shared library.
As this is an optional argument we can delete it here in the shared library and let the user of the shared library decide what she/he wants to set.
https://jeremylong.github.io/DependencyCheck/dependency-check-cli/arguments.html