### PR TITLE
Add git-crypt command

### DIFF
--- a/src/com/puzzleitc/Util.groovy
+++ b/src/com/puzzleitc/Util.groovy
@@ -1,0 +1,57 @@
+package com.puzzleitc.jenkins
+
+class Util {
+    static Map parseArgs(namedArgs, positionalArgs, List requiredParams, Map optionalParams = [:]) {
+
+        // null can be incorrectly assigned to namedArgs or positionalArgs if there are no other named or positional arguments, fix it
+        if (namedArgs == null) {
+            namedArgs = [:]
+            positionalArgs = ([null] as Object[]) + positionalArgs
+        }
+        if (positionalArgs == null) {
+            positionalArgs = ([null] as Object[])
+        }
+
+        // If the last argument is a closure it always goes into the last parameter
+        def positionalArgsCount = positionalArgs?.length
+        if (positionalArgsCount && positionalArgs[-1] instanceof Closure) {
+            println("closure")
+            def lastKey = optionalParams.size() ? optionalParams.keySet().last() : requiredParams[-1]
+            namedArgs[lastKey] = positionalArgs[-1]
+            positionalArgsCount--
+        }
+
+        int i = 0
+        for (def item: requiredParams) {
+            if (namedArgs.containsKey(item)) {
+                if (i < positionalArgsCount) {
+                    throw new IllegalArgumentException("Multiple values for argument '${item}'")
+                }
+            } else {
+                if (i < positionalArgsCount) {
+                    namedArgs[item] = positionalArgs[i]
+                } else {
+                    throw new IllegalArgumentException("Missing argument '${item}'")
+                }
+            }
+            i++
+        }
+
+        for (def item: optionalParams) {
+            if (namedArgs.containsKey(item.key)) {
+                if (i < positionalArgsCount) {
+                    throw new IllegalArgumentException("Multiple values for argument '${item.key}'")
+                }
+            } else {
+                if (i < positionalArgsCount) {
+                    namedArgs[item.key] = positionalArgs[i]
+                } else {
+                    namedArgs[item.key] = item.value
+                }
+            }
+            i++
+        }
+
+        return namedArgs
+    }
+}

--- a/src/com/puzzleitc/jenkins/command/GitCryptCommand.groovy
+++ b/src/com/puzzleitc/jenkins/command/GitCryptCommand.groovy
@@ -1,0 +1,30 @@
+package com.puzzleitc.jenkins.command
+
+import com.puzzleitc.jenkins.command.context.PipelineContext
+
+class GitCryptCommand {
+
+    private final PipelineContext ctx
+    private String credentialsId
+
+    GitCryptCommand(PipelineContext ctx) {
+        this.ctx = ctx
+    }
+
+    void execute() {
+        credentialsId = ctx.stepParams.getOptional('credentialsId', null) as String
+        if (credentialsId) {
+            ctx.info("-- git-crypt unlock --")
+            ctx.withCredentials([ctx.file(credentialsId: credentialsId, variable: 'GIT_CRYPT_KEYFILE')]) {
+                ctx.sh script: 'git-crypt unlock $GIT_CRYPT_KEYFILE'
+            }
+        }
+    }
+
+    void cleanUp() {
+        if (credentialsId) {
+            ctx.info("-- git-crypt lock --")
+            ctx.sh script: 'git-crypt lock'
+        }
+    }
+}

--- a/src/com/puzzleitc/jenkins/command/GitCryptCommand.groovy
+++ b/src/com/puzzleitc/jenkins/command/GitCryptCommand.groovy
@@ -5,26 +5,30 @@ import com.puzzleitc.jenkins.command.context.PipelineContext
 class GitCryptCommand {
 
     private final PipelineContext ctx
-    private String credentialsId
+    private boolean unlocked
 
     GitCryptCommand(PipelineContext ctx) {
         this.ctx = ctx
     }
 
     void execute() {
-        credentialsId = ctx.stepParams.getOptional('credentialsId', null) as String
+        def credentialsId = ctx.stepParams.getRequired('credentialsId') as String
+        def body = ctx.stepParams.getRequired('body') as Closure
+        def unlocked = false
         if (credentialsId) {
             ctx.info("-- git-crypt unlock --")
-            ctx.withCredentials([ctx.file(credentialsId: credentialsId, variable: 'GIT_CRYPT_KEYFILE')]) {
-                ctx.sh script: 'git-crypt unlock $GIT_CRYPT_KEYFILE'
+            try {
+                ctx.withCredentials([ctx.file(credentialsId: credentialsId, variable: 'GIT_CRYPT_KEYFILE')]) {
+                    ctx.sh script: 'git-crypt unlock $GIT_CRYPT_KEYFILE'
+                    unlocked = true
+                }
+                body()
+            } finally {
+                if (unlocked) {
+                    ctx.info("-- git-crypt lock --")
+                    ctx.sh script: 'git-crypt lock'
+                }
             }
-        }
-    }
-
-    void cleanUp() {
-        if (credentialsId) {
-            ctx.info("-- git-crypt lock --")
-            ctx.sh script: 'git-crypt lock'
         }
     }
 }

--- a/src/com/puzzleitc/jenkins/command/context/JenkinsInvoker.groovy
+++ b/src/com/puzzleitc/jenkins/command/context/JenkinsInvoker.groovy
@@ -26,6 +26,16 @@ Object callWithEnv(List<String> env, Closure<Object> closure) {
     }
 }
 
+Object callWithCredentials(List<Object> credentials, Closure<Object> closure) {
+    withCredentials(credentials) {
+        closure.call()
+    }
+}
+
+Object callFile(Map args) {
+    file(args)
+}
+
 def callAnsiColor(String colorMapName, Closure<Void> closure) {
     ansiColor(colorMapName) {
         closure.call()

--- a/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContext.groovy
+++ b/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContext.groovy
@@ -25,6 +25,16 @@ class JenkinsPipelineContext implements PipelineContext {
     }
 
     @Override
+    Object withCredentials(List<Object> credentials, Closure<Object> closure) {
+        invoker.callWithCredentials(credentials, closure)
+    }
+
+    @Override
+    Object file(Map map) {
+        invoker.callFile(map)
+    }
+
+    @Override
     String tool(String toolName) {
         invoker.callTool(toolName)
     }

--- a/src/com/puzzleitc/jenkins/command/context/PipelineContext.groovy
+++ b/src/com/puzzleitc/jenkins/command/context/PipelineContext.groovy
@@ -8,6 +8,10 @@ interface PipelineContext {
 
     Object withEnv(List<String> env, Closure<Object> closure)
 
+    Object withCredentials(List<Object> credentials, Closure<Object> closure)
+
+    Object file(Map map)
+
     String tool(String toolName)
 
     Object getOpenshift()

--- a/vars/withGitCrypt.groovy
+++ b/vars/withGitCrypt.groovy
@@ -1,13 +1,9 @@
 import com.puzzleitc.jenkins.command.GitCryptCommand
 import com.puzzleitc.jenkins.command.context.JenkinsPipelineContext
+import static com.puzzleitc.jenkins.Util.parseArgs
 
-def call(Map params = [:], body) {
-
-    GitCryptCommand command = new GitCryptCommand(new JenkinsPipelineContext(params))
-    try {
-        command.execute()
-        body()
-    } finally {
-        command.cleanUp()
-    }
+def call(Map namedArgs = [:], Object... positionalArgs) {
+    def args = parseArgs(namedArgs, positionalArgs, ["credentialsId", "body"])
+    GitCryptCommand command = new GitCryptCommand(new JenkinsPipelineContext(args))
+    command.execute()
 }

--- a/vars/withGitCrypt.groovy
+++ b/vars/withGitCrypt.groovy
@@ -1,0 +1,13 @@
+import com.puzzleitc.jenkins.command.GitCryptCommand
+import com.puzzleitc.jenkins.command.context.JenkinsPipelineContext
+
+def call(Map params = [:], body) {
+
+    GitCryptCommand command = new GitCryptCommand(new JenkinsPipelineContext(params))
+    try {
+        command.execute()
+        body()
+    } finally {
+        command.cleanUp()
+    }
+}

--- a/vars/withGitCrypt.txt
+++ b/vars/withGitCrypt.txt
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dl>
+    <dt>
+        <code>withGitCrypt(credentialisId:String):Object {…}</code>
+    </dt>
+    <dd>
+        <p>
+            Unlocks the Git repository in the current directory with <code>git-crypt</code> for the duration of the scope of the step
+            and locks it again afterwards. The repository is also relocked when an error occurs in the scope of the step.
+        </p>
+        <ul>
+            <li>
+                <b>credentialsId</b> - The credentials id of a <code>git-crypt</code> keyfile stored in the Jenkins credential
+                manager.
+            </li>
+        </ul>
+        <p style="margin-bottom: 0em;">
+            Example:
+        </p>
+        <pre style="margin-top: 0em; margin-left: 2em; color:#657383;"><code>
+withGitCrypt(credentialsId: 'my-git-crypt-keyfile') {
+    // work with decrypted files
+}
+// files are encrypted again
+        </code></pre>
+        <p>
+            For further information see <a href="https://github.com/AGWA/git-crypt">git-crypt Documentation</a>.
+        </p>
+    </dd>
+</dl>
+<!-- vim: set ft=html : -->
+<!-- code: set language=html : -->


### PR DESCRIPTION
Adds a withGitCrypt step which unlocks a Git repository with git-crypt during the scope of the step and locks it afterwards. See  vars/withGitCrypt.txt for more information.