### PR TITLE
Oc env fix

### DIFF
--- a/src/com/puzzleitc/jenkins/command/OpenshiftApplyCommand.groovy
+++ b/src/com/puzzleitc/jenkins/command/OpenshiftApplyCommand.groovy
@@ -27,17 +27,12 @@ class OpenshiftApplyCommand {
             def credentialsId = ctx.stepParams.getOptional('credentialsId') as String
             saToken = ctx.lookupServiceAccountToken(credentialsId, project)
         }
-        if (ctx.needsOcInstallation()) {
-            def oc_home = ctx.defaultOcInstallation()
-            ctx.withEnv(["PATH+OC=${oc_home}"]) {
-                executeOC(cluster, project, saToken, configuration, appLabel, rolloutKind, rolloutSelector, waitForRollout)
-            }
-        } else {
+        ctx.withOc() {
             executeOC(cluster, project, saToken, configuration, appLabel, rolloutKind, rolloutSelector, waitForRollout)
         }
     }
 
-    private void executeOC(String cluster, project, saToken, configuration, appLabel, rolloutKind, rolloutSelector, waitForRollout) {
+    private void executeOC(cluster, project, saToken, configuration, appLabel, rolloutKind, rolloutSelector, waitForRollout) {
         ctx.openshift.withCluster(cluster) {
             ctx.openshift.withProject(project) {
                 ctx.openshift.withCredentials(saToken) {

--- a/src/com/puzzleitc/jenkins/command/OpenshiftProcessCommand.groovy
+++ b/src/com/puzzleitc/jenkins/command/OpenshiftProcessCommand.groovy
@@ -40,15 +40,9 @@ class OpenshiftProcessCommand {
             '--ignore-unknown-parameters=' + ignoreUnknownParameters + ' ' +
             '--output=' + output
 
-        if (ctx.needsOcInstallation()) {
-            def oc_home = ctx.defaultOcInstallation()
-            ctx.withEnv(["PATH+OC=${oc_home}"]) {
-                result = executeOC(processScript)
-            }
-        } else {
+        ctx.withOc() {
             result = executeOC(processScript)
         }
-
         return result
     }
 

--- a/src/com/puzzleitc/jenkins/command/OpenshiftStartBuildCommand.groovy
+++ b/src/com/puzzleitc/jenkins/command/OpenshiftStartBuildCommand.groovy
@@ -19,7 +19,17 @@ class OpenshiftStartBuildCommand {
         def fromFile = ctx.stepParams.getOptional('fromFile') as String
         def credentialsId = ctx.stepParams.getOptional('credentialsId') as String
         def saToken = ctx.lookupServiceAccountToken(credentialsId, project)
-        ctx.ensureOcInstallation()
+        if (ctx.needsOcInstallation()) {
+            def oc_home = ctx.defaultOcInstallation()
+            ctx.withEnv(["PATH+OC=${oc_home}"]) {
+                executeOC(cluster, project, saToken, buildConfigName, fromDir, fromFile)
+            }
+        } else {
+            executeOC(cluster, project, saToken, buildConfigName, fromDir, fromFile)
+        }
+    }
+
+    private void executeOC(cluster, project, saToken, buildConfigName, fromDir, fromFile) {
         ctx.openshift.withCluster(cluster) {
             ctx.openshift.withProject(project) {
                 ctx.openshift.withCredentials(saToken) {

--- a/src/com/puzzleitc/jenkins/command/OpenshiftStartBuildCommand.groovy
+++ b/src/com/puzzleitc/jenkins/command/OpenshiftStartBuildCommand.groovy
@@ -23,6 +23,7 @@ class OpenshiftStartBuildCommand {
         ctx.openshift.withCluster(cluster) {
             ctx.openshift.withProject(project) {
                 ctx.openshift.withCredentials(saToken) {
+                    ctx.echo("openshift whoami: ${ctx.openshift.raw('whoami').out.trim()}")
                     ctx.echo("openshift cluster: ${ctx.openshift.cluster()}")
                     ctx.echo("openshift project: ${ctx.openshift.project()}")
                     def bc = ctx.openshift.selector("bc/${buildConfigName}")

--- a/src/com/puzzleitc/jenkins/command/OpenshiftStartBuildCommand.groovy
+++ b/src/com/puzzleitc/jenkins/command/OpenshiftStartBuildCommand.groovy
@@ -19,12 +19,7 @@ class OpenshiftStartBuildCommand {
         def fromFile = ctx.stepParams.getOptional('fromFile') as String
         def credentialsId = ctx.stepParams.getOptional('credentialsId') as String
         def saToken = ctx.lookupServiceAccountToken(credentialsId, project)
-        if (ctx.needsOcInstallation()) {
-            def oc_home = ctx.defaultOcInstallation()
-            ctx.withEnv(["PATH+OC=${oc_home}"]) {
-                executeOC(cluster, project, saToken, buildConfigName, fromDir, fromFile)
-            }
-        } else {
+        ctx.withOc() {
             executeOC(cluster, project, saToken, buildConfigName, fromDir, fromFile)
         }
     }

--- a/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContext.groovy
+++ b/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContext.groovy
@@ -108,16 +108,6 @@ Use 'withEnv(...) {...}' instead.""")
     }
 
     @Override
-    void ensureOcInstallation() {
-        int status = sh(script: 'command -v oc', returnStatus: true)
-        if (status != 0) {
-            def oc_home = executable('oc', DEFAULT_OC_TOOL_NAME)
-            def path_value = getEnv('PATH')
-            setEnv('PATH', "${oc_home}:${path_value}")
-        }
-    }
-
-    @Override
     String executable(String name, String toolName) {
         script.executable(name: name, toolName: toolName)
     }

--- a/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContext.groovy
+++ b/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContext.groovy
@@ -38,6 +38,13 @@ class JenkinsPipelineContext implements PipelineContext {
     @Override
     void setEnv(String name, String value) {
         script.env[name] = value
+
+        if (script.env[name] != value) {
+            script.error("""
+setEnv of ${name} failure!
+Variables defined inside 'environment {...}' cannot be overwritten!
+Use 'withEnv(...) {...}' instead.""")
+        }
     }
 
     @Override

--- a/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContext.groovy
+++ b/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContext.groovy
@@ -94,7 +94,18 @@ Use 'withEnv(...) {...}' instead.""")
     }
 
     @Override
-    Boolean needsOcInstallation() {
+    void withOc(Closure body) {
+        if (this.needsOcInstallation()) {
+            def oc_home = this.defaultOcInstallation()
+            this.withEnv(["PATH+OC=${oc_home}"]) {
+                body()
+            }
+        } else {
+            body()
+        }
+    }
+
+    private Boolean needsOcInstallation() {
         int status = sh(script: 'command -v oc', returnStatus: true)
         if (status == 0) {
             return false
@@ -102,8 +113,7 @@ Use 'withEnv(...) {...}' instead.""")
         return true
     }
 
-    @Override
-    String defaultOcInstallation() {
+    private String defaultOcInstallation() {
         return executable('oc', DEFAULT_OC_TOOL_NAME)
     }
 
@@ -206,5 +216,4 @@ Use 'withEnv(...) {...}' instead.""")
             }
         }
     }
-
 }

--- a/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContext.groovy
+++ b/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContext.groovy
@@ -94,6 +94,20 @@ Use 'withEnv(...) {...}' instead.""")
     }
 
     @Override
+    Boolean needsOcInstallation() {
+        int status = sh(script: 'command -v oc', returnStatus: true)
+        if (status == 0) {
+            return false
+        }
+        return true
+    }
+
+    @Override
+    String defaultOcInstallation() {
+        return executable('oc', DEFAULT_OC_TOOL_NAME)
+    }
+
+    @Override
     void ensureOcInstallation() {
         int status = sh(script: 'command -v oc', returnStatus: true)
         if (status != 0) {

--- a/src/com/puzzleitc/jenkins/command/context/PipelineContext.groovy
+++ b/src/com/puzzleitc/jenkins/command/context/PipelineContext.groovy
@@ -26,7 +26,11 @@ interface PipelineContext {
 
     String tool(String toolName)
 
+    String defaultOcInstallation()
+
     void ensureOcInstallation()
+
+    Boolean needsOcInstallation()
 
     String executable(String name, String toolName)
 

--- a/src/com/puzzleitc/jenkins/command/context/PipelineContext.groovy
+++ b/src/com/puzzleitc/jenkins/command/context/PipelineContext.groovy
@@ -26,9 +26,7 @@ interface PipelineContext {
 
     String tool(String toolName)
 
-    String defaultOcInstallation()
-
-    Boolean needsOcInstallation()
+    void withOc(Closure body)
 
     String executable(String name, String toolName)
 

--- a/src/com/puzzleitc/jenkins/command/context/PipelineContext.groovy
+++ b/src/com/puzzleitc/jenkins/command/context/PipelineContext.groovy
@@ -28,8 +28,6 @@ interface PipelineContext {
 
     String defaultOcInstallation()
 
-    void ensureOcInstallation()
-
     Boolean needsOcInstallation()
 
     String executable(String name, String toolName)

--- a/test/groovy/src/com/puzzleitc/jenkins/AvailableJDKsSpec.groovy
+++ b/test/groovy/src/com/puzzleitc/jenkins/AvailableJDKsSpec.groovy
@@ -4,7 +4,7 @@ import groovy.mock.interceptor.MockFor
 import spock.lang.*
 import com.puzzleitc.jenkins.AvailableJDKs
 
-class AvaiableJDKsSpec extends Specification {
+class AvailableJDKsSpec extends Specification {
 
     def 'it reads all available jdk versions' () {
         setup:

--- a/test/groovy/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContextSpec.groovy
+++ b/test/groovy/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContextSpec.groovy
@@ -23,9 +23,29 @@ class JenkinsPipelineContextSpec extends JenkinsPipelineSpecification {
         then:
         script.env[newEnvName] == newEnvValue
     }
+
+    /* TODO:
+    def 'It cannot update an env variable defined inside environment {...}' () {
+        setup:
+        def newEnvName = 'TEST'
+        def newEnvValue = 'test'
+        script.env[newEnvName] = 'uppps'
+        when:
+        jenkinsPipelineContext.setEnv(newEnvName, newEnvValue)
+        then:
+        1 * script.error("""
+setEnv of TEST failure!
+Variables defined inside 'environment {...}' cannot be overwritten!
+Use 'withEnv(...) {...}' instead.""")
+        script.env[newEnvName] == newEnvValue
+    }
+    */
+
 }
 
 // Class used to mock Script
 class Script {
     def env = [:]
+    def error() {
+    }
 }

--- a/test/groovy/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContextSpec.groovy
+++ b/test/groovy/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContextSpec.groovy
@@ -1,0 +1,31 @@
+package groovy.src.com.puzzleitc.jenkins.command.context
+
+import com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification
+import com.puzzleitc.jenkins.command.context.JenkinsPipelineContext
+
+class JenkinsPipelineContextSpec extends JenkinsPipelineSpecification {
+
+    def jenkinsPipelineContext
+    def script
+
+    def setup() {
+        script = new Script()
+        Map params = [:]
+        jenkinsPipelineContext = new JenkinsPipelineContext(script, params)
+    }
+
+    def 'It adds the given env variable' () {
+        setup:
+        def newEnvName = 'TEST'
+        def newEnvValue = 'test'
+        when:
+        jenkinsPipelineContext.setEnv(newEnvName, newEnvValue)
+        then:
+        script.env[newEnvName] == newEnvValue
+    }
+}
+
+// Class used to mock Script
+class Script {
+    def env = [:]
+}

--- a/test/groovy/util/Build.groovy
+++ b/test/groovy/util/Build.groovy
@@ -1,0 +1,7 @@
+package groovy.util
+
+// Interface used to mock openshift Build
+interface Build {
+    def logs(String[] params)
+    def object()
+}

--- a/test/groovy/util/BuildConfig.groovy
+++ b/test/groovy/util/BuildConfig.groovy
@@ -1,0 +1,6 @@
+package groovy.util
+
+// Interface used to mock openshift BuildConfig
+interface BuildConfig {
+    Build startBuild(String[] params)
+}

--- a/test/groovy/util/Result.groovy
+++ b/test/groovy/util/Result.groovy
@@ -1,0 +1,13 @@
+package groovy.util
+
+// Class used to mock openshift Result
+class Result {
+    def actions = []
+    int status
+
+    def Result() {}
+
+    def int status() {
+        return status
+    }
+}

--- a/test/groovy/util/RolloutManager.groovy
+++ b/test/groovy/util/RolloutManager.groovy
@@ -1,0 +1,6 @@
+package groovy.util
+
+// Interface used to mock openshift RolloutManager
+interface RolloutManager {
+    def status()
+}

--- a/test/groovy/util/Selector.java
+++ b/test/groovy/util/Selector.java
@@ -1,0 +1,6 @@
+package groovy.util;
+
+// Interface used to mock openshift Selector
+interface Selector {
+   RolloutManager rollout();
+}

--- a/test/groovy/vars/CheckSpec.groovy
+++ b/test/groovy/vars/CheckSpec.groovy
@@ -6,7 +6,7 @@ class CheckSpec extends JenkinsPipelineSpecification {
 
     def check = loadPipelineScriptForTest('vars/check.groovy')
 
-    def 'It aborts the pipline' () {
+    def 'It aborts the pipeline' () {
         setup:
             check.getBinding().setVariable('currentBuild', [:])
         when:
@@ -16,7 +16,7 @@ class CheckSpec extends JenkinsPipelineSpecification {
             1 * getPipelineMock("error").call('missing parameter: hallo')
     }
 
-    def 'It doesn\'t abort the pipline' () {
+    def 'It doesn\'t abort the pipeline' () {
         setup:
             check.getBinding().setVariable('currentBuild', [result: 'null'])
             check.getBinding().setVariable('params', [hallo: 'test'])

--- a/test/groovy/vars/OpenshiftApplySpec.groovy
+++ b/test/groovy/vars/OpenshiftApplySpec.groovy
@@ -49,6 +49,9 @@ class OpenshiftApplySpec extends JenkinsPipelineSpecification {
         then:
         2 * getPipelineMock('sh').call({ ['script': 'command -v oc', 'returnStatus': 'true'] }) >> 1
         1 * getPipelineMock('executable').call(['name': 'oc', 'toolName': 'oc_3_11']) >> '/path/bin'
+        1 * getPipelineMock('openshift.withCluster')(_)
+        1 * getPipelineMock('openshift.withProject')(_)
+        1 * getPipelineMock('openshift.withCredentials')(_)
         1 * getPipelineMock('openshift.raw').call('whoami') >> [out: "jenkins"]
         1 * getPipelineMock('openshift.raw').call(['convert', '-f', 'null/temp.yaml']) >> [actions: [[cmd: "oc --server=https://openshift.puzzle.ch --insecure-skip-tls-verify --namespace=pitc-jenkinscicd-prod --token=XXXXX  convert -f /var/lib/jenkins/workspace/sgilgen/shared-library-test/1636550271093/temp.yaml"]]]
         1 * getPipelineMock('openshift.apply').call([args.configuration, '-l', 'app=label', '--prune']) >> output
@@ -81,6 +84,9 @@ class OpenshiftApplySpec extends JenkinsPipelineSpecification {
             assert true == _arguments[0]['returnStatus']
             return 0
         }
+        1 * getPipelineMock('openshift.withCluster')(_)
+        1 * getPipelineMock('openshift.withProject')(_)
+        1 * getPipelineMock('openshift.withCredentials')(_)
         1 * getPipelineMock('openshift.raw').call('whoami') >> [out: "jenkins"]
         1 * getPipelineMock('openshift.raw')(_) >> { _arguments ->
             assert 'apply' == _arguments[0][0]
@@ -126,6 +132,9 @@ class OpenshiftApplySpec extends JenkinsPipelineSpecification {
             assert true == _arguments[0]['returnStatus']
             return 0
         }
+        1 * getPipelineMock('openshift.withCluster')(_)
+        1 * getPipelineMock('openshift.withProject')(_)
+        1 * getPipelineMock('openshift.withCredentials')(_)
         1 * getPipelineMock('openshift.raw').call('whoami') >> [out: "jenkins"]
         1 * getPipelineMock('openshift.raw').call(['apply', '-f', 'null/temp.yaml', '--dry-run=server']) >> [actions: [[cmd: "oc --server=https://openshift.openshift.com --insecure-skip-tls-verify --namespace=myproject --token=XXXXX  apply -f /temp.yaml"]]]
         1 * getPipelineMock('openshift.apply').call([args.configuration, '-l', 'app=label', '--prune']) >> output
@@ -172,6 +181,9 @@ class OpenshiftApplySpec extends JenkinsPipelineSpecification {
             assert true == _arguments[0]['returnStatus']
             return 0
         }
+        1 * getPipelineMock('openshift.withCluster')(_)
+        1 * getPipelineMock('openshift.withProject')(_)
+        1 * getPipelineMock('openshift.withCredentials')(_)
         1 * getPipelineMock('openshift.raw').call('whoami') >> [out: "jenkins"]
         1 * getPipelineMock('openshift.raw').call(['apply', '-f', 'null/temp.yaml', '--dry-run=server']) >> [actions: [[cmd: "oc --server=https://openshift.openshift.com --insecure-skip-tls-verify --namespace=myproject --token=XXXXX  apply -f /temp.yaml"]]]
         1 * getPipelineMock('openshift.apply').call([args.configuration, '-l', 'app=label', '--prune']) >> output
@@ -193,14 +205,4 @@ class OpenshiftApplySpec extends JenkinsPipelineSpecification {
                  ]]
     }
 
-}
-
-// Interface used to mock openshift Selector
-interface Selector {
-    def rollout()
-}
-
-// Interface used to mock openshift RolloutManager
-interface RolloutManager {
-    def status()
 }

--- a/test/groovy/vars/OpenshiftApplySpec.groovy
+++ b/test/groovy/vars/OpenshiftApplySpec.groovy
@@ -193,7 +193,6 @@ class OpenshiftApplySpec extends JenkinsPipelineSpecification {
                  ]]
     }
 
-
 }
 
 // Interface used to mock openshift Selector

--- a/test/groovy/vars/OpenshiftStartBuildCommandSpec.groovy
+++ b/test/groovy/vars/OpenshiftStartBuildCommandSpec.groovy
@@ -1,0 +1,130 @@
+package groovy.vars
+
+import com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification
+
+class OpenshiftStartBuildCommandSpec extends JenkinsPipelineSpecification {
+
+    /**
+     * TODO: test startBuild command
+     */
+
+    def openshiftStartBuild = loadPipelineScriptForTest('vars/openshiftStartBuild.groovy')
+
+    def setup() {
+        explicitlyMockPipelineStep('executable')
+    }
+
+    def 'it should fail when parameter is not set'(args) {
+
+        when:
+        openshiftStartBuild.call(args)
+
+        then:
+        1 * getPipelineMock("echo").call({ it.contains("missing required step parameter: '${args.missing}'") })
+        1 * getPipelineMock("error").call('Build failed') >> { throw new RuntimeException() }
+        thrown(RuntimeException)
+
+        where:
+        args << [[project        : "myProject",
+                  cluster        : "myCluster",
+                  missing        : "buildConfigName"],
+                 [cluster        : "myCluster",
+                  buildConfigName: "buildConfig",
+                  missing        : "project"],
+                 [project        : "myProject",
+                  buildConfigName: "buildConfig",
+                  missing        : "cluster"]]
+
+    }
+
+    def 'it calls startBuild'(args) {
+
+        // mock Result
+        def myResult = new Result().with {
+            actions = [[cmd: "oc startBuild ..."]]
+            status = 0
+            it
+        }
+
+        // mock Build to return the Result mock and check that the method is called once
+        def myBuild = Mock(Build) {
+            1 * logs(_) >> myResult
+            1 * object() >> [status: [phase: "Success"]]
+        }
+        // mock BuildConfig to return the Build mock and check that the method is called once
+        def myBuildConfig = Mock(BuildConfig) {
+            1 * startBuild(_) >> myBuild
+        }
+
+        setup:
+        openshiftStartBuild.getBinding().setVariable('env', [:])
+        openshiftStartBuild.getBinding().setVariable('secretValue', 'dGVzdA==')
+
+        when:
+        openshiftStartBuild.call(args)
+
+        then:
+        1 * getPipelineMock('sh').call({ ['script': 'command -v oc', 'returnStatus': 'true'] }) >> 0
+        0 * getPipelineMock('executable').call(['name': 'oc', 'toolName': 'oc_3_11']) >> '/path/bin'
+        1 * getPipelineMock('openshift.withCluster')(_)
+        1 * getPipelineMock('openshift.withProject')(_)
+        1 * getPipelineMock('openshift.withCredentials')(_)
+        1 * getPipelineMock('openshift.raw').call('whoami') >> [out: "jenkins"]
+        1 * getPipelineMock('openshift.selector')(_) >> { _arguments ->
+            assert 'bc/buildConfig' == _arguments[0]
+            return myBuildConfig  // the BuildConfig mock providing the startBuild method
+        }
+
+        where:
+        args << [[project         : "myProject",
+                  cluster         : "oc4-test-cluster",
+                  buildConfigName : "buildConfig"]]
+
+    }
+
+    def 'it calls install oc_3_11 tool and startBuild'(args) {
+
+        // mock Result
+        def myResult = new Result().with {
+            actions = [[cmd: "oc startBuild ..."]]
+            status = 0
+            it
+        }
+
+        // mock Build to return the Result mock and check that the method is called once
+        def myBuild = Mock(Build) {
+            1 * logs(_) >> myResult
+            1 * object() >> [status: [phase: "Success"]]
+        }
+        // mock BuildConfig to return the Build mock and check that the method is called once
+        def myBuildConfig = Mock(BuildConfig) {
+            1 * startBuild(_) >> myBuild
+        }
+
+        setup:
+        openshiftStartBuild.getBinding().setVariable('env', [:])
+        openshiftStartBuild.getBinding().setVariable('secretValue', 'dGVzdA==')
+
+        when:
+        openshiftStartBuild.call(args)
+
+        then:
+        1 * getPipelineMock('sh').call({ ['script': 'command -v oc', 'returnStatus': 'true'] }) >> 1
+        1 * getPipelineMock('executable').call(['name': 'oc', 'toolName': 'oc_3_11']) >> '/path/bin'
+        1 * getPipelineMock('openshift.withCluster')(_)
+        1 * getPipelineMock('openshift.withProject')(_)
+        1 * getPipelineMock('openshift.withCredentials')(_)
+        1 * getPipelineMock('openshift.raw').call('whoami') >> [out: "jenkins"]
+        1 * getPipelineMock('openshift.selector')(_) >> { _arguments ->
+            assert 'bc/buildConfig' == _arguments[0]
+            return myBuildConfig  // the BuildConfig mock providing the startBuild method
+        }
+
+        where:
+        args << [[project         : "myProject",
+                  cluster         : "oc4-test-cluster",
+                  buildConfigName : "buildConfig"]]
+
+    }
+
+}


### PR DESCRIPTION
ctx.ensureOcInstallation() did not work when PATH var was defined in root environment {....}
Env vars from root environment {....} can not be changed. Only using withEnv(){...} can change those vars.

I changed the oc commands using that method.

**Attention**: new is a check for setEnv in JenkinsPipelineContext. This would make the pipeline fail if a env var can not be changed.
```
    void setEnv(String name, String value) {
        script.env[name] = value

        if (script.env[name] != value) {
            script.error("""
setEnv of ${name} failure!
Variables defined inside 'environment {...}' cannot be overwritten!
Use 'withEnv(...) {...}' instead.""")
        }
    }
```

Is this check a good idea?