### PR TITLE
removed running on cluster case from lookupServiceAccountToken

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation "org.jenkins-ci.main:jenkins-core:2.225", withoutIcu
     implementation "org.jenkins-ci.plugins:badge:1.8@jar"
     implementation "org.jenkins-ci.plugins:pipeline-maven:3.9.3@jar" // dependency for MavenReport
+    implementation "org.jenkins-ci.plugins:credentials-binding:1.27.1@jar"
 
     implementation "org.slf4j:jcl-over-slf4j:1.7.25"
     testImplementation "org.slf4j:log4j-over-slf4j:1.7.25"

--- a/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContext.groovy
+++ b/src/com/puzzleitc/jenkins/command/context/JenkinsPipelineContext.groovy
@@ -184,12 +184,7 @@ Use 'withEnv(...) {...}' instead.""")
     @Override
     String lookupServiceAccountToken(String credentialsId, project) {
         if (credentialsId == null) {
-            // Token is only needed when not running on Kubernetes cluster
-            if (getEnv('KUBERNETES_PORT') == null) {
-                lookupTokenFromCredentials("${project}${DEFAULT_CREDENTIAL_ID_SUFFIX}")
-            } else {
-                return null
-            }
+            lookupTokenFromCredentials("${project}${DEFAULT_CREDENTIAL_ID_SUFFIX}")
         } else {
             lookupTokenFromCredentials(credentialsId)
         }


### PR DESCRIPTION
lookupServiceAccountToken included a case for when the jenkins master was running in the cluster

>// Token is only needed when not running on Kubernetes cluster

This does not appy if you want to deploy to another cluster or the jenkins-master installaion does not have the cluster role.

closes https://gitlab.puzzle.ch/pitc-cicd/cicd-team-organisation/-/issues/146